### PR TITLE
[CICD-5808] update sonarqube docker pull jervis

### DIFF
--- a/sonarqube/docker-compose.yml
+++ b/sonarqube/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   sonarqube:
     init: true
     # https://hub.docker.com/_/sonarqube/
-    image: sonarqube:7.9.1-community
+    image: nexus.303net.net:8443/library/sonarqube:7.9.1-community
     volumes:
       - conf:/opt/sonarqube/conf
       - extensions:/opt/sonarqube/extensions


### PR DESCRIPTION
See also: [CICD-5808](https://jira.integralads.com/browse/CICD-5808)

Update docker pull usage only in `integralads/jervis`. No upstream
changes incorporated at this time.